### PR TITLE
Allow for versions of python > 3.5

### DIFF
--- a/pfioh/C_snode.py
+++ b/pfioh/C_snode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 
 """
     NAME

--- a/pfioh/dgmsocket.py
+++ b/pfioh/dgmsocket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 # 
 # NAME
 #

--- a/pfioh/message.py
+++ b/pfioh/message.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 
 import  sys
 import  os

--- a/pfioh/pfioh.py
+++ b/pfioh/pfioh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 
 import  sys
 


### PR DESCRIPTION
Specifying the version as 3.5 doesn't allow for versions greater than 3.5.