### PR TITLE
template change for mount-point

### DIFF
--- a/openshift/pfioh-openshift-template.json
+++ b/openshift/pfioh-openshift-template.json
@@ -72,7 +72,7 @@
                 "terminationMessagePath": "/dev/termination-log",
                 "volumeMounts": [
                   {
-                    "mount-path": "/etc/swift",
+                    "mountPath": "/etc/swift",
                     "name": "swift-credentials",
                     "readOnly": true
                   }


### PR DESCRIPTION
/cc @danmcp The template was not working with "mount-path" for origin 3.5 and I believe it won't work with latest releases as well.


Signed-off-by: ravisantoshgudimetla <ravisantoshgudimetla@gmail.com>

