### PR TITLE
Fix pfioh hello with Openshift route

### DIFF
--- a/pfioh/pfioh.py
+++ b/pfioh/pfioh.py
@@ -501,6 +501,11 @@ class StoreHandler(BaseHTTPRequestHandler):
                 d_ret['echoBack']               = {}
                 d_ret['echoBack']['msg']        = d_meta['echoBack']
                 b_status                        = True
+        
+        self.send_response(200)
+        self.end_headers()
+
+        d_ret['User-agent'] = self.headers['user-agent']
 
         return { 'stdout': { 
                             'd_ret':   d_ret,


### PR DESCRIPTION
The pfioh hello command would return a bad gateway error with the openshift route
due to the fact the pfioh would not send a 200 response code back.
Added that into pfioh.py and now we can get a response with the openshift route.

Fixes issue https://github.com/redhat-university-partnerships/radiology/issues/27

Signed-off-by: umohnani8 <umohnani@redhat.com>