### PR TITLE
Fix import path for virtualenv and version bump.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ####################
-pfioh - v2.0.0.0
+pfioh - v2.0.0.2
 ####################
 
 .. image:: https://badge.fury.io/py/pfioh.svg

--- a/bin/pfioh
+++ b/bin/pfioh
@@ -25,8 +25,12 @@ try:
     import mount_dir
     import swift_store
 except:
+    # system lib path
     sys.path.insert(1, os.path.join(get_python_lib(True, True), 'site-packages'))
     sys.path.insert(1, os.path.join(get_python_lib(True, True), 'site-packages/pfioh'))
+    # virtual env lib path
+    sys.path.insert(1, os.path.join(get_python_lib(True, False), 'site-packages'))
+    sys.path.insert(1, os.path.join(get_python_lib(True, False), 'site-packages/pfioh'))
     import pfioh
     import mount_dir
     import swift_store
@@ -34,7 +38,7 @@ except:
 from    pfmisc._colors             import Colors
 
 str_defIP   = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
-str_version = "2.0.0.0"
+str_version = "2.0.0.2"
 str_desc    = Colors.CYAN + """
         __ _       _
        / _(_)     | |

--- a/cube_before_script.sh
+++ b/cube_before_script.sh
@@ -11,5 +11,5 @@ export STOREBASE=$(pwd)/FS/remote
 docker-compose up -d
 docker-compose exec chris_dev_db sh -c 'while ! mysqladmin -uroot -prootp status 2> /dev/null; do sleep 5; done;'
 docker-compose exec chris_dev_db mysql -uroot -prootp -e 'GRANT ALL PRIVILEGES ON *.* TO "chris"@"%"'
-docker-compose exec chris_dev python manage.py migrate
+# docker-compose exec chris_dev python manage.py migrate
 docker swarm init --advertise-addr 127.0.0.1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 setup(
       name             =   'pfioh',
-      version          =   '2.0.0.0',
+      version          =   '2.0.0.2',
       description      =   'Path-and-File-IO-over-HTTP',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
Minor updates -- noticed `pfioh` in pip was missing some imports in virtualenv