### PR TITLE
Add logic check on specialHandling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 language: python
 python: 
-  - "3.5"
+  - "3.6"
 env:
   global:
     - DOCKER_COMPOSE_VERSION=1.18.0
@@ -17,7 +17,7 @@ before_install:
       
 # command to install dependencies
 install: 
-  - if [ "$TO_TEST" = "pfioh" ]; then pip install .; fi
+  - if [ "$TO_TEST" = "pfioh" ]; then sudo apt-get install -y libgnutls28-dev && pip install .; fi
 
 before_script:
   - if [ "$TO_TEST" = "cube" ]; then ./cube_before_script.sh; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,9 @@ RUN apt-get update \
   && echo "localuser:localuser" | chpasswd                            \
   && adduser localuser sudo                                           \
   && apt-get install -y libssl-dev libcurl4-openssl-dev bsdmainutils vim net-tools inetutils-ping \
+  && apt-get install -y libgnutls28-dev                               \
   && pip install --upgrade pip                                        \
-  && pip3 install --prefix /usr /tmp/pfioh                            \  
-  && pip3 install pudb                                                \
-  && pip3 install keystoneauth1                                       \
-  && pip3 install python-keystoneclient                               \
-  && pip3 install pfmisc>=1.3.30                                      \
-  && pip3 install python-swiftclient                                  \
+  && pip3 install /tmp/pfioh                                          \  
   && rm -rf /tmp/pfioh                                                \
   && chmod 777 /dock                                                  \
   && chmod 777 /dock/docker-entrypoint.py                             \

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ####################
-pfioh - v2.1.1.6
+pfioh - v2.2.0.4
 ####################
 
 .. image:: https://badge.fury.io/py/pfioh.svg

--- a/bin/pfioh
+++ b/bin/pfioh
@@ -3,7 +3,7 @@
 # (c) 2017- Fetal-Neonatal Neuroimaging & Developmental Science Center
 #                   Boston Children's Hospital
 #
-#              http://childrenshospital.org/FNNDSC/
+#                        http://fnndsc.org
 #                        dev@babyMRI.org
 #
 
@@ -22,27 +22,17 @@ import  pudb
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), '../pfioh'))
 try:
     import pfioh
-    import mount_dir
-    import swift_store
+    import mount_dir    as MountDir
+    import swift_store  as SwiftStore
 except:
-    # system lib path
-    sys.path.insert(1, os.path.join(get_python_lib(True, True), 'site-packages'))
-    sys.path.insert(1, os.path.join(get_python_lib(True, True), 'site-packages/pfioh'))
-    # virtual env lib path
-    sys.path.insert(1, os.path.join(get_python_lib(True, False), 'site-packages/pfioh'))
-    try:
-        import pfioh
-        from   pfioh.mount_dir      import MountDir
-        from   pfioh.swift_store    import SwiftStore
-    except:
-        import pfioh
-        import mount_dir
-        import swift_store
+    import pfioh
+    from   pfioh.mount_dir      import MountDir         as MountDir
+    from   pfioh.swift_store    import SwiftStore       as SwiftStore
 
 from    pfmisc._colors             import Colors
 
 str_defIP   = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
-str_version = "2.1.1.6"
+str_version = "2.2.0.4"
 str_desc    = Colors.CYAN + """
         __ _       _
        / _(_)     | |
@@ -57,6 +47,13 @@ str_desc    = Colors.CYAN + """
                             Path-File-IO-over-HTTP
 
            A simple IO handler that pushes/pulls file paths over http
+
+        (c) 2017+ Fetal-Neonatal Neuroimaging & Developmental Science Center
+                            Boston Children's Hospital
+
+                               http://fnndsc.org
+                                dev@babyMRI.org
+
 
                               -- version """ + \
              Colors.YELLOW + str_version + Colors.CYAN + """ --
@@ -347,7 +344,7 @@ if args.b_version:
 if args.b_swiftStorage:
     server = pfioh.ThreadedHTTPServer((args.ip, args.port), swift_store.SwiftStore)
 else:
-    server = pfioh.ThreadedHTTPServer((args.ip, args.port), mount_dir.MountDir) 
+    server = pfioh.ThreadedHTTPServer((args.ip, args.port), MountDir) 
 
 server.setup(args = vars(args), desc = str_desc, ver = str_version)
 

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -31,7 +31,7 @@ def pfioh_do(args, unknown):
 
     str_otherArgs   = ' '.join(unknown)
 
-    str_CMD = "/usr/bin/pfioh --forever %s" % (str_otherArgs)
+    str_CMD = "/usr/local/bin/pfioh --forever %s" % (str_otherArgs)
     return str_CMD
 
 parser  = argparse.ArgumentParser(description = str_desc)

--- a/pfioh/__init__.py
+++ b/pfioh/__init__.py
@@ -1,3 +1,3 @@
-from .pfioh   import StoreHandler, ThreadedHTTPServer, base64_process, zip_process, zipdir
-from .swift_store import SwiftStore
-from .mount_dir import MountDir
+from .pfioh         import StoreHandler, ThreadedHTTPServer, base64_process, zip_process, zipdir
+from .swift_store   import SwiftStore
+from .mount_dir     import MountDir

--- a/pfioh/pfioh.py
+++ b/pfioh/pfioh.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import logging
+logging.disable(logging.CRITICAL)
+
 import  sys
 import  stat
 
@@ -328,7 +331,6 @@ class StoreHandler(BaseHTTPRequestHandler):
     def denyAuth(self):
         d_ret = {
                 "message": "Unauthorized Client Request",
-                "error": error,
                 'status': False
                 }
 
@@ -964,11 +966,16 @@ class StoreHandler(BaseHTTPRequestHandler):
         d_ret           = {}
         b_status        = False
         str_path        = ''
+        b_openshift     = False
+
         for k,v in kwargs.items():
             if k == 'meta':         d_meta          = v
             if k == 'path':         str_path        = v
 
-        if 'specialHandling' in d_meta:
+        if 'serviceMan' in d_meta.keys():
+            b_openshift = d_meta['serviceMan'] == 'openshift'
+
+        if 'specialHandling' in d_meta and not b_openshift:
             d_preop = d_meta['specialHandling']
             if 'cmd' in d_preop.keys():
                 str_cmd     = d_postop['cmd']
@@ -1021,11 +1028,15 @@ class StoreHandler(BaseHTTPRequestHandler):
         d_ret           = {}
         b_status        = False
         str_path        = ''
+        b_openshift     = False
 
         for k,v in kwargs.items():
             if k == 'meta':         d_meta          = v
 
-        if 'specialHandling' in d_meta:
+        if 'serviceMan' in d_meta.keys():
+            b_openshift = d_meta['serviceMan'] == 'openshift'
+
+        if 'specialHandling' in d_meta and not b_openshift:
             d_postop = d_meta['specialHandling']
             if 'cleanup' in d_postop.keys():
                 if d_postop['cleanup']:
@@ -1067,12 +1078,15 @@ class StoreHandler(BaseHTTPRequestHandler):
         d_ret           = {}
         b_status        = False
         str_path        = ''
+        b_openshift     = False
 
         for k,v in kwargs.items():
             if k == 'meta':         d_meta          = v
             if k == 'path':         str_path        = v
 
-        if 'specialHandling' in d_meta:
+        if 'serviceMan' in d_meta.keys():
+            b_openshift = d_meta['serviceMan'] == 'openshift'
+        if 'specialHandling' in d_meta and not b_openshift:
             d_postop = d_meta['specialHandling']
             if 'cmd' in d_postop.keys():
                 str_cmd     = d_postop['cmd']

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 setup(
       name             =   'pfioh',
-      version          =   '2.1.1.6',
+      version          =   '2.2.0.4',
       description      =   'Path-and-File-IO-over-HTTP',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
In the case of the MOC (i.e. openshift), the `specialHandling` JSON directive that is passed by CUBE should not be processed. This is a first attempt at a less ugly solution. If the JSON directive also contains a 

```json
{
    "serviceType": "openshift"
}

then the specialHandling code is not executed.