### PR TITLE
Fix http headers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ####################
-pfioh - v2.2.0.8
+pfioh - v3.0.0.0
 ####################
 
 .. image:: https://badge.fury.io/py/pfioh.svg

--- a/bin/pfioh
+++ b/bin/pfioh
@@ -19,23 +19,18 @@ import  pudb
 # The following convolutions are necessary to accommodate both
 # development and deployed instances of the 'pfioh.py' module
 # and related dependencies.
-sys.path.insert(1, os.path.join(os.path.dirname(__file__), '../pfioh'))
 
 import signal
 import threading
-try:
-    import pfioh
-    import mount_dir    as MountDir
-    import swift_store  as SwiftStore
-except:
-    import pfioh
-    from   pfioh.mount_dir      import MountDir         as MountDir
-    from   pfioh.swift_store    import SwiftStore       as SwiftStore
+
+import pfioh
+from pfioh.mount_dir import MountDir as MountDir
+from pfioh.swift_store import SwiftStore as SwiftStore
 
 from    pfmisc._colors             import Colors
 
 str_defIP   = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
-str_version = "2.2.0.8"
+str_version = "3.0.0.0"
 str_desc    = Colors.CYAN + """
         __ _       _
        / _(_)     | |

--- a/pfioh/pfioh.py
+++ b/pfioh/pfioh.py
@@ -106,6 +106,7 @@ class StoreHandler(BaseHTTPRequestHandler):
 
     def buffered_response(self, filePath):
         self.send_response(200)
+        self.end_headers()
         f = open(filePath, "rb")
         buf = 16*1024
         while 1:
@@ -231,6 +232,9 @@ class StoreHandler(BaseHTTPRequestHandler):
                                 key         = d_remote['key'],
                                 d_ret       = d_ret
                             )
+        # TODO
+        # self.getData calls StoreHandler.buffered_response
+        # which writes the body. so is ret_client doing anything here?
         d_ret['postop']      = self.do_GET_postop(  meta          = d_meta)
         self.ret_client(d_ret)
         self.dp.qprint(json.dumps(d_ret, indent = 4), comms = 'tx')

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,23 @@
-import  sys
-from    setuptools import setup
+from os import path
+from setuptools import setup
 
-# Make sure we are running python3.5+
-if 10 * sys.version_info[0]  + sys.version_info[1] < 35:
-    sys.exit("Sorry, only Python 3.5+ is supported.")
-
-
-def readme():
-    with open('README.rst') as f:
-        return f.read()
+with open(path.join(path.abspath(path.dirname(__file__)), 'README.rst')) as f:
+    readme = f.read()
 
 setup(
-      name             =   'pfioh',
-      version          =   '2.2.0.8',
-      description      =   'Path-and-File-IO-over-HTTP',
-      long_description =   readme(),
-      author           =   'Rudolph Pienaar',
-      author_email     =   'rudolph.pienaar@gmail.com',
-      url              =   'https://github.com/FNNDSC/pfioh',
-      packages         =   ['pfioh'],
-      install_requires =   ['pycurl', 'pyzmq', 'webob', 'pudb', 'psutil', 'keystoneauth1', 'python-keystoneclient', 'python-swiftclient', 'pfmisc'],
-      test_suite       =   'nose.collector',
-      tests_require    =   ['nose'],
-      scripts          =   ['bin/pfioh'],
-      license          =   'MIT',
-      zip_safe         =   False
-     )
+    name             =   'pfioh',
+    version          =   '3.0.0.0',
+    description      =   'Path-and-File-IO-over-HTTP',
+    long_description =   readme,
+    author           =   'Rudolph Pienaar',
+    author_email     =   'rudolph.pienaar@gmail.com',
+    url              =   'https://github.com/FNNDSC/pfioh',
+    packages         =   ['pfioh'],
+    install_requires =   ['pycurl', 'pyzmq', 'webob', 'pudb', 'psutil', 'keystoneauth1', 'python-keystoneclient', 'python-swiftclient', 'pfmisc'],
+    test_suite       =   'nose.collector',
+    tests_require    =   ['nose'],
+    scripts          =   ['bin/pfioh'],
+    license          =   'MIT',
+    zip_safe         =   False,
+    python_requires  =   '>=3.6'
+)


### PR DESCRIPTION
Fixes the bug described here:

https://github.com/FNNDSC/pfurl/blob/ef18de4f5d40700286a8753b52c1b56e74c6d1e7/pfurl/pfurl.py#L1435-L1457

HTTP headers are set correctly:

```
Content-Type: application/json
Content-Length: <N>
```

The body is vanilla minified JSON.

DO NOT MERGE until **pfcon** (a client of _pfioh_) has its **pfurl** usage fixed:

https://github.com/FNNDSC/pfcon/blob/74b5debc15d025dd54ffe240bbe7f089bcc3fbed/pfcon/pfcon.py#L425

Change to `b_httpResponseBodyParse = False`

With this PR, `b_httpResponseBodyParse` option of _pfurl_ is obsolete.

As a (good but could cause tests to break) side-effect, the body does not have unnecessary spaces in the minified JSON.