### PR TITLE
Fix more headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,5 @@ RUN pip3 install ${APPROOT}  \
 #USER localuser
 
 WORKDIR "/home/localuser"
-ENTRYPOINT ["pfioh"]
+ENTRYPOINT ["pfioh", "--forever", "--httpResponse", "--createDirsAsNeeded"]
 EXPOSE 5055

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email     =   'rudolph.pienaar@gmail.com',
     url              =   'https://github.com/FNNDSC/pfioh',
     packages         =   ['pfioh'],
-    install_requires =   ['pycurl', 'pyzmq', 'webob', 'pudb', 'psutil', 'keystoneauth1', 'python-keystoneclient', 'python-swiftclient', 'pfmisc'],
+    install_requires =   ['pycurl', 'pyzmq', 'webob', 'pudb', 'psutil', 'keystoneauth1', 'python-keystoneclient', 'python-swiftclient', 'pfmisc==2.0.2'],
     test_suite       =   'nose.collector',
     tests_require    =   ['nose'],
     scripts          =   ['bin/pfioh'],


### PR DESCRIPTION
FIxes a bug where when using the options `pfioh --enableTokenAuth --tokenPath openshift/example-config.cfg` the HTTP response headers were incorrect

```
HTTP/1.0 400 Bad Request.
Server: BaseHTTP/0.6 Python/3.8.6
Date: Wed, 11 Nov 2020 22:02:43 GMT
HTTP/1.0 401 Unauthorized
Server: BaseHTTP/0.6 Python/3.8.6
Date: Wed, 11 Nov 2020 22:02:43 GMT
Connection: close
Content-Type: text/html;charset=utf-8
Content-Length: 463

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
        "http://www.w3.org/TR/html4/strict.dtd">
<html>
    <head>
        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
        <title>Error response</title>
    </head>
    <body>
        <h1>Error response</h1>
        <p>Error code: 401</p>
        <p>Message: Unauthorized.</p>
        <p>Error code explanation: 401 - No permission -- see authorization schemes.</p>
    </body>
</html>
```

This PR fixes the problem.

Note: we prefer the standard response from `BaseHTTPRequestHandler.send_error` instead of `pfmisc.Auth`'s strangeness.

This PR should sum up the outstanding problems with valid HTTP response headers, fixing any `502 Bad Gateway` issues from Openshift routes.